### PR TITLE
Refactor/19/account controller 반환 방식 변경

### DIFF
--- a/src/main/java/com/market/marketplacebackend/account/controller/AccountController.java
+++ b/src/main/java/com/market/marketplacebackend/account/controller/AccountController.java
@@ -1,5 +1,6 @@
 package com.market.marketplacebackend.account.controller;
 
+import com.market.marketplacebackend.account.dto.AccountResponseDto;
 import com.market.marketplacebackend.common.ServiceResult;
 import com.market.marketplacebackend.account.domain.Account;
 import com.market.marketplacebackend.account.dto.LoginDto;
@@ -21,14 +22,22 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping("/signup")
-    public ResponseEntity<ServiceResult<Account>> signUp(@Valid @RequestBody SignUpDto signUpDto){
-        ServiceResult<Account> result = accountService.join(signUpDto);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<ServiceResult<AccountResponseDto>> signUp(@Valid @RequestBody SignUpDto signUpDto){
+        Account serviceResult = accountService.join(signUpDto);
+
+        AccountResponseDto accountResponseDto = AccountResponseDto.fromEntity(serviceResult);
+        ServiceResult<AccountResponseDto> finalResult = ServiceResult.success("회원가입 성공", accountResponseDto);
+
+        return ResponseEntity.ok(finalResult);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ServiceResult<Account>> login(@Valid @RequestBody LoginDto loginDto){
-        ServiceResult<Account> result = accountService.login(loginDto);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<ServiceResult<AccountResponseDto>> login(@Valid @RequestBody LoginDto loginDto){
+        Account serviceResult = accountService.login(loginDto);
+
+        AccountResponseDto accountResponseDto = AccountResponseDto.fromEntity(serviceResult);
+        ServiceResult<AccountResponseDto> finalResult = ServiceResult.success("로그인 성공", accountResponseDto);
+
+        return ResponseEntity.ok(finalResult);
     }
 }

--- a/src/main/java/com/market/marketplacebackend/account/dto/AccountResponseDto.java
+++ b/src/main/java/com/market/marketplacebackend/account/dto/AccountResponseDto.java
@@ -2,7 +2,6 @@ package com.market.marketplacebackend.account.dto;
 
 import com.market.marketplacebackend.account.domain.Account;
 import com.market.marketplacebackend.common.enums.AccountRole;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/market/marketplacebackend/account/dto/AccountResponseDto.java
+++ b/src/main/java/com/market/marketplacebackend/account/dto/AccountResponseDto.java
@@ -1,0 +1,30 @@
+package com.market.marketplacebackend.account.dto;
+
+import com.market.marketplacebackend.account.domain.Account;
+import com.market.marketplacebackend.common.enums.AccountRole;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountResponseDto {
+    private String name;
+    private String email;
+    private String phoneNumber;
+    @Enumerated(EnumType.STRING)
+    private AccountRole accountRole;
+
+    public static AccountResponseDto fromEntity(Account account) {
+        return AccountResponseDto.builder()
+                .name(account.getName())
+                .email(account.getEmail())
+                .phoneNumber(account.getPhoneNumber())
+                .accountRole(account.getAccountRole())
+                .build();
+    }
+}

--- a/src/main/java/com/market/marketplacebackend/account/dto/AccountResponseDto.java
+++ b/src/main/java/com/market/marketplacebackend/account/dto/AccountResponseDto.java
@@ -15,7 +15,6 @@ public class AccountResponseDto {
     private String name;
     private String email;
     private String phoneNumber;
-    @Enumerated(EnumType.STRING)
     private AccountRole accountRole;
 
     public static AccountResponseDto fromEntity(Account account) {

--- a/src/main/java/com/market/marketplacebackend/account/service/AccountService.java
+++ b/src/main/java/com/market/marketplacebackend/account/service/AccountService.java
@@ -1,10 +1,8 @@
 package com.market.marketplacebackend.account.service;
 
-import com.market.marketplacebackend.cart.domain.Cart;
-import com.market.marketplacebackend.cart.repository.CartRepository;
+import com.market.marketplacebackend.cart.service.CartService;
 import com.market.marketplacebackend.common.exception.BusinessException;
 import com.market.marketplacebackend.common.exception.ErrorCode;
-import com.market.marketplacebackend.common.ServiceResult;
 import com.market.marketplacebackend.account.domain.Account;
 import com.market.marketplacebackend.account.dto.LoginDto;
 import com.market.marketplacebackend.account.dto.SignUpDto;
@@ -19,21 +17,21 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
     private final HttpSession httpSession;
-    private final CartRepository cartRepository;
+    private final CartService cartService;
 
-    public ServiceResult<Account> join(SignUpDto signUpDto) {
+    public Account join(SignUpDto signUpDto) {
         if(accountRepository.existsByEmail(signUpDto.getEmail())){
             throw new BusinessException(ErrorCode.EMAIL_DUPLICATE);
         }
 
         Account account = signUpDto.toEntity();
         Account savedAccount = accountRepository.save(account);
-        cartRepository.save(new Cart(account));
+        cartService.createCartForAccount(savedAccount);
 
-        return ServiceResult.success("회원 가입 성공", savedAccount);
+        return savedAccount;
     }
 
-    public ServiceResult<Account> login(LoginDto loginDto) {
+    public Account login(LoginDto loginDto) {
         Account account = accountRepository.findByEmail(loginDto.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_NOT_FOUND));
 
@@ -43,7 +41,7 @@ public class AccountService {
 
         httpSession.setAttribute("UserId", account.getId());
 
-        return ServiceResult.success("로그인 성공", account);
+        return account;
     }
 
 }

--- a/src/main/java/com/market/marketplacebackend/cart/dto/CartItemAddRequestDto.java
+++ b/src/main/java/com/market/marketplacebackend/cart/dto/CartItemAddRequestDto.java
@@ -1,5 +1,6 @@
 package com.market.marketplacebackend.cart.dto;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/market/marketplacebackend/cart/service/CartService.java
+++ b/src/main/java/com/market/marketplacebackend/cart/service/CartService.java
@@ -1,5 +1,6 @@
 package com.market.marketplacebackend.cart.service;
 
+import com.market.marketplacebackend.account.domain.Account;
 import com.market.marketplacebackend.cart.domain.Cart;
 import com.market.marketplacebackend.cart.domain.CartItem;
 import com.market.marketplacebackend.cart.dto.CartItemAddRequestDto;
@@ -23,6 +24,11 @@ public class CartService {
     private final CartRepository cartRepository;
     private final ProductRepository productRepository;
     private final CartItemRepository cartItemRepository;
+
+    @Transactional
+    public void createCartForAccount(Account savedAccount) {
+        cartRepository.save(new Cart(savedAccount));
+    }
 
     @Transactional(readOnly = true)
     public Cart getCart(Long accountId) {

--- a/src/test/java/com/market/marketplacebackend/account/AccountControllerTest.java
+++ b/src/test/java/com/market/marketplacebackend/account/AccountControllerTest.java
@@ -1,7 +1,6 @@
 package com.market.marketplacebackend.account;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.market.marketplacebackend.common.ServiceResult;
 import com.market.marketplacebackend.account.controller.AccountController;
 import com.market.marketplacebackend.account.domain.Account;
 import com.market.marketplacebackend.account.dto.LoginDto;
@@ -55,9 +54,7 @@ class AccountControllerTest {
 
         Account account = signUpDto.toEntity();
 
-        ServiceResult<Account> result = ServiceResult.success("회원가입 성공", account);
-
-        when(accountService.join(any(SignUpDto.class))).thenReturn(result);
+        when(accountService.join(any(SignUpDto.class))).thenReturn(account);
 
         // when & then
         mockMvc.perform(post("/user/signup")
@@ -104,9 +101,7 @@ class AccountControllerTest {
                 .email("test@example.com")
                 .build();
 
-        ServiceResult<Account> result = ServiceResult.success("로그인 성공", account);
-
-        when(accountService.login(any(LoginDto.class))).thenReturn(result);
+        when(accountService.login(any(LoginDto.class))).thenReturn(account);
 
         //when & then
         MvcResult mvcResult = mockMvc.perform(post("/user/login")

--- a/src/test/java/com/market/marketplacebackend/account/AccountServiceTest.java
+++ b/src/test/java/com/market/marketplacebackend/account/AccountServiceTest.java
@@ -1,9 +1,8 @@
 package com.market.marketplacebackend.account;
 
-// Removed unused import for UserController
+import com.market.marketplacebackend.cart.service.CartService;
 import com.market.marketplacebackend.common.exception.BusinessException;
 import com.market.marketplacebackend.common.exception.ErrorCode;
-import com.market.marketplacebackend.common.ServiceResult;
 import com.market.marketplacebackend.account.domain.Account;
 import com.market.marketplacebackend.account.dto.LoginDto;
 import com.market.marketplacebackend.account.dto.SignUpDto;
@@ -23,8 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AccountServiceTest {
@@ -36,6 +34,9 @@ public class AccountServiceTest {
 
     @Mock
     private HttpSession httpSession;
+
+    @Mock
+    private CartService cartService;
 
     @Test
     @DisplayName("회원가입 성공(서비스)")
@@ -58,14 +59,16 @@ public class AccountServiceTest {
 
         when(accountRepository.save(any(Account.class)))
                 .thenReturn(account);
+        doNothing().when(cartService).createCartForAccount(any(Account.class));
+
         //when
-        ServiceResult<Account> result = accountService.join(signUpDto);
+        Account result = accountService.join(signUpDto);
 
         //then
-        assertThat(result.getData().getEmail()).isEqualTo(signUpDto.getEmail());
-        assertThat(result.getData().getName()).isEqualTo(signUpDto.getName());
-        assertThat(result.getData().getPassword()).isEqualTo(signUpDto.getPassword());
-        assertThat(result.getData().getPhoneNumber()).isEqualTo(signUpDto.getPhoneNumber());
+        assertThat(result.getEmail()).isEqualTo(signUpDto.getEmail());
+        assertThat(result.getName()).isEqualTo(signUpDto.getName());
+        assertThat(result.getPassword()).isEqualTo(signUpDto.getPassword());
+        assertThat(result.getPhoneNumber()).isEqualTo(signUpDto.getPhoneNumber());
         verify(accountRepository).existsByEmail("test@example.com");
         verify(accountRepository).save(any(Account.class));
     }
@@ -107,11 +110,11 @@ public class AccountServiceTest {
         when(accountRepository.findByEmail("test@example.com")).thenReturn(Optional.ofNullable(account));
 
         //when
-        ServiceResult<Account> loginCustomer = accountService.login(loginDto);
+        Account loginCustomer = accountService.login(loginDto);
 
         //then
-        assertThat(loginCustomer.getData().getEmail()).isEqualTo(loginDto.getEmail());
-        assertThat(loginCustomer.getData().getPassword()).isEqualTo(loginDto.getPassword());
+        assertThat(loginCustomer.getEmail()).isEqualTo(loginDto.getEmail());
+        assertThat(loginCustomer.getPassword()).isEqualTo(loginDto.getPassword());
         verify(accountRepository).findByEmail("test@example.com");
         verify(httpSession).setAttribute("UserId", 1L);
     }

--- a/src/test/java/com/market/marketplacebackend/account/UserIntegrationTest.java
+++ b/src/test/java/com/market/marketplacebackend/account/UserIntegrationTest.java
@@ -2,6 +2,7 @@ package com.market.marketplacebackend.account;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.market.marketplacebackend.common.enums.AccountRole;
 import com.market.marketplacebackend.common.exception.ErrorCode;
 import com.market.marketplacebackend.common.ServiceResult;
 import com.market.marketplacebackend.account.domain.Account;
@@ -45,6 +46,7 @@ public class UserIntegrationTest {
                 .email("test@example.com")
                 .password("password123")
                 .phoneNumber("010-1234-5678")
+                .accountRole(AccountRole.CUSTOMER)
                 .build();
 
         mockMvc.perform(post("/user/signup")
@@ -52,7 +54,7 @@ public class UserIntegrationTest {
                 .content(objectMapper.writeValueAsString(signUpDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("회원 가입 성공"));
+                .andExpect(jsonPath("$.message").value("회원가입 성공"));
 
         Optional<Account> customer = accountRepository.findByEmail("test@example.com");
         assertThat(customer).isPresent();


### PR DESCRIPTION
# account controller 반환 방식 변경

## 개요

기존 도메인을 직접 반환하는 방식에서 Dto 반환 방식으로 변경

### 환경 설정

[환경 설정 변경사항이 있는 경우 작성]

## 파일 변경사항

### 추가된 파일

- AccountResponseDto - 반환값 Dto 추가(name, email, phoneNumber, accountRole)

### 수정된 파일

- AccountController - 반환값 변경 Account -> AccountResponseDto
- AccountControllerTest - 원코드 변경에 따른 테스트코드 수정
- AccountServiceTest - 원코드 변경에 따른 테스트코드 수정
- UserIntegrationTest - 원코드 변경에 따른 테스트코드 수정

### API 결과

### 성공 케이스

```json
{
"name": "홍길동",
"email": "[hong@example.com](mailto:hong@example.com)",
"phoneNumber": "010-1234-5678",
"accountRole": "USER"
}
```